### PR TITLE
allow specifying custom mappings for the effective motion execution

### DIFF
--- a/autoload/smartword.vim
+++ b/autoload/smartword.vim
@@ -79,14 +79,11 @@ endfunction
 
 
 
-
 " Misc.  "{{{1
+
 function! s:current_char(pos)  "{{{2
   return getline(a:pos[1])[a:pos[2] - 1]
 endfunction
-
-
-
 
 function! s:move(motion_command, mode, times)  "{{{2
   call s:_move(a:motion_command, a:mode, a:times)
@@ -111,7 +108,7 @@ function! s:_move(motion_command, mode, times)
     while !0
       let lastpos = newpos
 
-      execute 'normal!' a:motion_command
+      execute "normal \<Plug>(smartword-basic-" . a:motion_command . ')'
       if &selection ==# 'exclusive'
       \  && a:motion_command ==# 'e'
       \  && (a:mode ==# 'v' || a:mode ==# 'o')

--- a/doc/smartword.txt
+++ b/doc/smartword.txt
@@ -90,6 +90,16 @@ MAPPINGS					*smartword-mappings*
 			and Operator-pending mode.
 
 
+<Plug>(smartword-basic-w)			 *<Plug>(smartword-basic-w)*
+<Plug>(smartword-basic-b)			 *<Plug>(smartword-basic-b)*
+<Plug>(smartword-basic-e)		         *<Plug>(smartword-basic-e)*
+<Plug>(smartword-basic-ge)		         *<Plug>(smartword-basic-ge)*
+                        Effective mappings for the motions, defaulting to the
+                        built-in |w|, |b|, |e| and |ge|.
+                        Can be used to make smartword work with other motion
+                        plugins.
+			These mappings are defined in Normal mode.
+
 
 
 ==============================================================================
@@ -117,6 +127,20 @@ EXAMPLES					*smartword-examples*
 	noremap ,b  b
 	noremap ,e  e
 	noremap ,ge  ge
+
+(D) Use CamelCaseMotion as effective motion:
+>
+	nmap <Plug>(smartword-basic-w) <Plug>CamelCaseMotion_w
+
+    Now the cursor will jump to N and x on
+
+        someName_xyz
+
+
+
+
+==============================================================================
+BUGS						*smartword-bugs*
 <
 
 

--- a/plugin/smartword.vim
+++ b/plugin/smartword.vim
@@ -27,8 +27,6 @@ if exists('g:loaded_smartword')
 endif
 
 
-
-
 nnoremap <silent> <Plug>(smartword-w)  :<C-u>call smartword#move('w','n')<CR>
 nnoremap <silent> <Plug>(smartword-b)  :<C-u>call smartword#move('b','n')<CR>
 nnoremap <silent> <Plug>(smartword-e)  :<C-u>call smartword#move('e','n')<CR>
@@ -45,6 +43,10 @@ onoremap <silent> <Plug>(smartword-e)  :<C-u>call smartword#move('e','o')<CR>
 onoremap <silent> <Plug>(smartword-ge)  :<C-u>call smartword#move('ge','o')<CR>
 
 
+noremap <silent> <Plug>(smartword-basic-w) w
+noremap <silent> <Plug>(smartword-basic-b) b
+noremap <silent> <Plug>(smartword-basic-e) e
+noremap <silent> <Plug>(smartword-basic-ge) ge
 
 
 let g:loaded_smartword = 1


### PR DESCRIPTION
If g:smartword_allow_remap is true, `normal` is used instead of
`normal!`, thus allowing the executed command to be remapped. The dictionary
g:smartword_commands is read for the desired mapping, making it possible to
use custom motions, e.g. from plugins like CamelCaseMotion.
